### PR TITLE
Support for Vertica 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM debian:9.2
 MAINTAINER Sumit Chawla <sumitkchawla@gmail.com>
 
 # Update the image
@@ -8,15 +8,19 @@ RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install -y openssh-server openssh-client mcelog gdb sysstat dialog
 
 # grab gosu for easy step-down from root
-RUN apt-get install -y curl \
+RUN apt-get install -y apt-utils curl \
 	&& curl -o /usr/local/bin/gosu -SL 'https://github.com/tianon/gosu/releases/download/1.1/gosu' \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-get clean
 
 # Set locale for all system 
-RUN locale-gen en_US en_US.UTF-8
-RUN dpkg-reconfigure locales 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8 
+
+RUN apt-get clean
 
 # Vertica requires bash as default shell
 ENV SHELL "/bin/bash"
@@ -30,8 +34,8 @@ RUN echo "dbadmin -       nice    0" >> /etc/security/limits.conf
 RUN echo "dbadmin -       nofile  65536" >> /etc/security/limits.conf
 
 # Install package 
-ADD vertica.deb /tmp/vertica.deb
-RUN dpkg -i /tmp/vertica.deb
+ADD vertica9.deb /tmp/vertica9.deb
+RUN dpkg -i /tmp/vertica9.deb
 
 # In theory, someone should make things work without ignoring the errors.
 # But that's in theory, and for now, this seems sufficient.
@@ -39,7 +43,8 @@ RUN /opt/vertica/sbin/install_vertica --license CE --accept-eula --hosts 127.0.0
 
 # Test DB creation as dbuser
 USER dbadmin
-RUN /opt/vertica/bin/admintools -t create_db -s localhost -d docker -c /home/dbadmin/docker/catalog -D /home/dbadmin/docker/data
+RUN /opt/vertica/bin/admintools -t create_db -s 127.0.0.1 -d docker -c /home/dbadmin/docker/catalog -D /home/dbadmin/docker/data --skip-fs-checks
+# RUN cat /opt/vertica/log/adminTools.log
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Docker Image for Vertica
+# Docker Image for Vertica 9
 
 The image is available in Docker registry at https://registry.hub.docker.com/u/sumitchawla/vertica/
 
-Base OS is Ubuntu 14.04.
+Base OS is Debian 9.2.
 
 ## Usage:
 You can either pull the image from Docker Registry using following command:
@@ -11,7 +11,7 @@ You can either pull the image from Docker Registry using following command:
 docker pull sumitchawla/vertica
 ```
 
-Or, build your own image using following command. Download the Vertica DEB package from https://my.vertica.com and put it in this folder as "vertica.deb".
+Or, build your own image using following command. Download the Vertica DEB package from https://my.vertica.com and put it in this folder as "vertica9.deb".
 Then run:
 ```bash
 docker build -t sumitchawla/vertica .


### PR DESCRIPTION
Here are some updates I have done to have a Vertica 9 docker container on a Debian. I succeded to install vertica 9 on a Debian 9.2.1 VM that's why I have changed the image base of the Docker file.

The vertica install file was vertica_9.0.0-0_amd64.deb.

I had to add "--skip-fs-checks" in "admintools -t create_db" don't really know why...

Thank you for your works.